### PR TITLE
Fix: Make navigation menu responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -476,4 +476,16 @@
             h1 {
                 font-size: 2.5rem;
             }
+
+            nav {
+                flex-direction: column;
+                align-items: center; /* Center items when stacked vertically */
+            }
+
+            .nav-link {
+                padding: 0.75rem 1rem; /* Adjust padding for smaller screens */
+                margin: 0.5rem 0; /* Add vertical margin */
+                text-align: center; /* Center text within links */
+                width: 90%; /* Make links take more width to ensure text fits */
+            }
         }


### PR DESCRIPTION
The navigation menu items now stack vertically on screens narrower than 768px. This addresses an issue where menu item text would get truncated on mobile devices.

Changes:
- Modified `css/style.css` to add `flex-direction: column` to the `nav` element within the `@media (max-width: 768px)` media query.
- Adjusted padding, margin, text-alignment, and width for `.nav-link` elements on smaller screens to ensure text visibility and proper layout.