### PR TITLE
Fix: Adjust menu font size for responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -477,15 +477,15 @@
                 font-size: 2.5rem;
             }
 
-            nav {
-                flex-direction: column;
-                align-items: center; /* Center items when stacked vertically */
-            }
-
             .nav-link {
-                padding: 0.75rem 1rem; /* Adjust padding for smaller screens */
-                margin: 0.5rem 0; /* Add vertical margin */
-                text-align: center; /* Center text within links */
-                width: 90%; /* Make links take more width to ensure text fits */
+                font-size: 0.9rem; /* Reduce font size for smaller screens */
+                padding: 0.6rem 1rem; /* Adjust padding slightly */
+            }
+        }
+
+        @media (max-width: 480px) {
+            .nav-link {
+                font-size: 0.8rem; /* Further reduce font size for very small screens */
+                padding: 0.5rem 0.8rem; /* Further adjust padding */
             }
         }


### PR DESCRIPTION
I've updated the navigation menu to remain horizontal on all screen sizes. The font size for menu items is now reduced on smaller screens to prevent text truncation, as per your feedback.

Changes:
- I reverted previous CSS that stacked menu items vertically.
- I added CSS rules in `css/style.css` to decrease `font-size` and adjust `padding` for `.nav-link` elements within media queries at `max-width: 768px` and `max-width: 480px`.