### PR TITLE
Fix: Enforce horizontal menu layout and adjust font size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -129,6 +129,7 @@
             display: flex;
             justify-content: center;
             padding: 1rem 0;
+            flex-wrap: nowrap;
         }
 
         .nav-link {
@@ -478,14 +479,14 @@
             }
 
             .nav-link {
-                font-size: 0.9rem; /* Reduce font size for smaller screens */
-                padding: 0.6rem 1rem; /* Adjust padding slightly */
+                font-size: 0.85rem; /* Adjusted font size */
+                padding: 0.6rem 0.8rem; /* Adjusted padding */
             }
         }
 
         @media (max-width: 480px) {
             .nav-link {
-                font-size: 0.8rem; /* Further reduce font size for very small screens */
-                padding: 0.5rem 0.8rem; /* Further adjust padding */
+                font-size: 0.75rem; /* Further adjusted font size */
+                padding: 0.5rem 0.6rem; /* Further adjusted padding */
             }
         }


### PR DESCRIPTION
I've ensured that the navigation menu items always remain in a single horizontal line across all screen sizes, preventing any vertical stacking, as per your feedback.

Changes:
- Added `flex-wrap: nowrap;` to the main `nav` element style in `css/style.css` to prevent menu items from wrapping.
- Further adjusted `font-size` and `padding` for `.nav-link` elements within media queries (`@media (max-width: 768px)` and `@media (max-width: 480px)`) to improve text visibility and fit within the constrained horizontal space on smaller screens.