### PR TITLE
Fix: Update footer mailto link color to match scheme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -417,6 +417,14 @@
             font-size: 0.9rem;
         }
 
+        footer a {
+            color: var(--accent);
+        }
+
+        footer a:hover {
+            color: var(--secondary);
+        }
+
         .back-to-top {
             position: fixed;
             bottom: 2rem;


### PR DESCRIPTION
The mailto link in the footer was using the default footer text color. This change updates the link color to use the --accent color defined in the site's color scheme, making it more prominent and consistent with other highlighted elements like contact icons.

A hover effect has also been added, changing the link color to --secondary on mouseover for better user feedback.